### PR TITLE
管理者用の施術メニュー管理機能（CRUD）を実装

### DIFF
--- a/app/controllers/admin/menus_controller.rb
+++ b/app/controllers/admin/menus_controller.rb
@@ -1,0 +1,45 @@
+class Admin::MenusController < Admin::BaseController
+  before_action :set_menu, only: %i[edit update destroy]
+
+  def index
+    @menus = Menu.includes(:slot).order(:start_date)
+  end
+
+  def new
+    @menu = Menu.new
+  end
+
+  def create
+    @menu = Menu.new(menu_params)
+    if @menu.save
+      redirect_to admin_menus_path, notice: "メニューを作成しました"
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @menu.update(menu_params)
+      redirect_to admin_menus_path, notice: "メニューを更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @menu.destroy
+    redirect_to admin_menus_path, notice: "メニューを削除しました"
+  end
+
+  private
+
+  def set_menu
+    @menu = Menu.find(params[:id])
+  end
+
+  def menu_params
+    params.require(:menu).permit(:name, :description, :price, :duration, :start_date, :end_date, :available, :slot_id)
+  end
+end

--- a/app/helpers/admin/menus_helper.rb
+++ b/app/helpers/admin/menus_helper.rb
@@ -1,0 +1,2 @@
+module Admin::MenusHelper
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,12 @@
+class Menu < ApplicationRecord
+  belongs_to :slot
+
+  validates :name, :price, :duration, presence: true
+  validates :price, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :available, -> {
+    where(available: true)
+    .where("start_date IS NULL OR start_date <= ?", Date.today)
+    .where("end_date IS NULL OR end_date >= ?", Date.today)
+  }
+end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -2,7 +2,7 @@ class Slot < ApplicationRecord
   validates :start_time, :end_time, presence: true
   validate :end_time_after_start_time
   validate :no_overlap
-
+  has_many :menus, dependent: :destroy
   private
 
   # 終了時間は開始時間より後であることを保証

--- a/app/views/admin/menus/_form.html.erb
+++ b/app/views/admin/menus/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_with model: [:admin, @menu], local: true do |f| %>
+  <div>
+    <%= f.label :name, "メニュー名" %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :description, "説明" %>
+    <%= f.text_area :description %>
+  </div>
+
+  <div>
+    <%= f.label :price, "価格（円）" %>
+    <%= f.number_field :price %>
+  </div>
+
+  <div>
+    <%= f.label :duration, "施術時間（分）" %>
+    <%= f.number_field :duration %>
+  </div>
+
+  <div>
+    <%= f.label :slot_id, "時間枠" %>
+    <%= f.collection_select :slot_id, Slot.order(:start_time), :id, ->(s) { "#{s.start_time.strftime("%H:%M")}〜#{s.end_time.strftime("%H:%M")}" }, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= f.label :start_date, "提供開始日" %>
+    <%= f.date_field :start_date %>
+  </div>
+
+  <div>
+    <%= f.label :end_date, "提供終了日" %>
+    <%= f.date_field :end_date %>
+  </div>
+
+  <div>
+    <%= f.label :available, "提供中" %>
+    <%= f.check_box :available %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/menus/edit.html.erb
+++ b/app/views/admin/menus/edit.html.erb
@@ -1,0 +1,3 @@
+<h2><%= action_name == "new" ? "新規メニュー作成" : "メニュー編集" %></h2>
+<%= render "form" %>
+<%= link_to "戻る", admin_menus_path %>

--- a/app/views/admin/menus/index.html.erb
+++ b/app/views/admin/menus/index.html.erb
@@ -1,0 +1,31 @@
+<h2>施術メニュー一覧</h2>
+
+<%= link_to "新規メニュー作成", new_admin_menu_path, class: "btn btn-primary" %>
+
+<table>
+  <thead>
+    <tr>
+      <th>名前</th>
+      <th>時間枠</th>
+      <th>価格</th>
+      <th>期間</th>
+      <th>提供中</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @menus.each do |menu| %>
+      <tr>
+        <td><%= menu.name %></td>
+        <td><%= menu.slot&.start_time.strftime("%H:%M") %>〜<%= menu.slot&.end_time.strftime("%H:%M") %></td>
+        <td><%= menu.price %>円</td>
+        <td><%= menu.start_date %>〜<%= menu.end_date %></td>
+        <td><%= menu.available ? "○" : "×" %></td>
+        <td>
+          <%= link_to "編集", edit_admin_menu_path(menu) %> |
+          <%= link_to "削除", admin_menu_path(menu), data: { turbo_method: :delete } %> %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/menus/new.html.erb
+++ b/app/views/admin/menus/new.html.erb
@@ -1,0 +1,3 @@
+<h2><%= action_name == "new" ? "新規メニュー作成" : "メニュー編集" %></h2>
+<%= render "form" %>
+<%= link_to "戻る", admin_menus_path %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", media: "all" %>
-    <%= javascript_importmap_tags %> 
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>
@@ -16,7 +16,7 @@
         <ul>
           <li><%= link_to "🏠 ダッシュボード", admin_dashboard_index_path %></li>
           <li><%= link_to "🕒 時間枠管理", admin_slots_path %></li>
-          <li><%= link_to "📋 メニュー管理", "#" %>（後で実装）</li>
+          <li><%= link_to "📋 メニュー管理", admin_menus_path %></li>
           <li><%= link_to "👤 マイページへ", mypage_path %></li>
         </ul>
       </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     root to: "dashboard#index"
     resources :reservations
     resources :slots
+    resources :menus
   end
 
   # ヘルスチェック

--- a/db/migrate/20250702133451_create_menus.rb
+++ b/db/migrate/20250702133451_create_menus.rb
@@ -1,0 +1,17 @@
+class CreateMenus < ActiveRecord::Migration[8.0]
+  def change
+    create_table :menus do |t|
+      t.string  :name,        null: false
+      t.text    :description
+      t.integer :price,       null: false
+      t.integer :duration,    null: false
+      t.date    :start_date
+      t.date    :end_date
+      t.boolean :available,   null: false, default: true
+
+      t.references :slot,     null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_132110) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_02_133451) do
+  create_table "menus", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.integer "price", null: false
+    t.integer "duration", null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.boolean "available", default: true, null: false
+    t.bigint "slot_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slot_id"], name: "index_menus_on_slot_id"
+  end
+
   create_table "slots", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "start_time"
     t.datetime "end_time"
@@ -32,4 +46,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_132110) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "menus", "slots"
 end

--- a/test/controllers/admin/menus_controller_test.rb
+++ b/test/controllers/admin/menus_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::MenusControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/menus.yml
+++ b/test/fixtures/menus.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+  price: 1
+  duration: 1
+  start_date: 2025-07-02
+  end_date: 2025-07-02
+  available: false
+  slot: one
+
+two:
+  name: MyString
+  description: MyText
+  price: 1
+  duration: 1
+  start_date: 2025-07-02
+  end_date: 2025-07-02
+  available: false
+  slot: two

--- a/test/models/menu_test.rb
+++ b/test/models/menu_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 📋 プルリクエストタイトル

**管理者用の施術メニュー管理機能（CRUD）の実装**

---

## 🗂 概要

管理者が施術メニューを登録・編集・削除できる機能を実装しました。  
これにより、期間限定メニューの管理や施術メニューの柔軟な追加・更新が可能になります。

---

## ✅ 実装内容

- `Menu`モデルの作成（施術メニューの情報を管理）
- 管理画面用コントローラ `Admin::MenusController` の作成
  - メニューの一覧表示、新規作成、編集、削除機能（CRUD）
- ビューファイルの追加（`index`, `new`, `edit`, `_form`）
- `admin/layout` に「📋 メニュー管理」へのリンクを追加
- `routes.rb` に `admin/menus` リソースを追加
- `Slot`モデルとのアソシエーション（`menu belongs_to :slot`）

---

## 📸 動作確認

- [x] 管理者ログイン後、「📋 メニュー管理」リンクから遷移できる
- [x] メニューの登録・編集・削除ができる
- [x] バリデーションエラーが適切に表示される
- [x] `slot`との紐付けが正しく行える

---

## 🔗 関連Issue

- Issue #4：施術メニュー管理機能の実装

---

## 📝 補足（あれば）

- メニューは `Slot` に紐づくように設計していますが、今後 `Slot` との多対多など、柔軟な構造への変更も検討可能です。
