### PR TITLE
【まとめ実装】管理者用時間枠＆メニュー管理機能＋予約作成機能の実装（ISSUE4〜6対応）

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,18 @@
 class Admin::DashboardController < Admin::BaseController
-  # authenticate_user! は BaseControllerで行っているので不要
   def index
+    # 今日〜7日後までの予約一覧（ユーザー・メニュー付き）
+    @upcoming_reservations = Reservation
+      .includes(:user, :menu, :slot)
+      .where(slots: { start_time: Time.current.beginning_of_day..7.days.from_now.end_of_day })
+      .references(:slot)
+      .order("slots.start_time ASC")
+
+    # Slotごとの予約数サマリー
+    @slot_summary = Slot
+      .left_joins(:reservations)
+      .where(start_time: Time.current.beginning_of_day..7.days.from_now.end_of_day)
+      .group("slots.id")
+      .select("slots.*, COUNT(reservations.id) AS reservation_count")
+      .order("slots.start_time ASC")
   end
 end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,8 +1,55 @@
-# app/controllers/admin/reservations_controller.rb
-class Admin::ReservationsController < Admin::BaseController
+class Admin::ReservationsController < ApplicationController
+  http_basic_authenticate_with name: ENV["ADMIN_USER"], password: ENV["ADMIN_PASS"]
+
+  before_action :set_reservation, only: [ :edit, :update, :destroy ]
+  before_action :load_form_collections, only: [ :new, :create, :edit, :update ]
+
   def index
-    @reservations = Reservation.all
+    @reservations = Reservation.includes(:user, :slot, :menu).all.order(created_at: :desc)
   end
 
-  # 例：編集や削除などのアクションも必要に応じて追加
+  def new
+    @reservation = Reservation.new
+  end
+
+  def create
+    @reservation = Reservation.new(reservation_params)
+    if @reservation.save
+      redirect_to admin_reservations_path, notice: "予約を登録しました"
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @reservation.update(reservation_params)
+      redirect_to admin_reservations_path, notice: "予約を更新しました"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @reservation.destroy
+    redirect_to admin_reservations_path, notice: "予約を削除しました"
+  end
+
+  private
+
+  def set_reservation
+    @reservation = Reservation.find(params[:id])
+  end
+
+  def load_form_collections
+    @users = User.all.order(:name)
+    @menus = Menu.available
+    @slots = Slot.all.order(:start_time)
+  end
+
+  def reservation_params
+    params.require(:reservation).permit(:user_id, :slot_id, :menu_id)
+  end
 end

--- a/app/controllers/users/reservations_controller.rb
+++ b/app/controllers/users/reservations_controller.rb
@@ -1,0 +1,49 @@
+# app/controllers/users/reservations_controller.rb
+class Users::ReservationsController < ApplicationController
+  before_action :set_reservation, only: [ :edit, :update ]
+
+  def index
+    @reservations = current_user.reservations.includes(:menu, :slot).order(created_at: :desc)
+  end
+  def new
+    @reservation = current_user.reservations.new
+    @menus = Menu.available
+    @slots = Slot.all
+  end
+
+  def create
+    @reservation = current_user.reservations.new(reservation_params)
+    if @reservation.save
+      redirect_to mypage_path, notice: "予約が完了しました"
+    else
+      @menus = Menu.available
+      @slots = Slot.all
+      render :new
+    end
+  end
+
+  def edit
+    @menus = Menu.available
+    @slots = Slot.all
+  end
+
+  def update
+    if @reservation.update(reservation_params)
+      redirect_to mypage_path, notice: "予約を更新しました"
+    else
+      @menus = Menu.available
+      @slots = Slot.all
+      render :edit
+    end
+  end
+
+  private
+
+  def set_reservation
+    @reservation = current_user.reservations.find(params[:id])
+  end
+
+  def reservation_params
+    params.require(:reservation).permit(:slot_id, :menu_id)
+  end
+end

--- a/app/helpers/users/reservations_helper.rb
+++ b/app/helpers/users/reservations_helper.rb
@@ -1,0 +1,2 @@
+module Users::ReservationsHelper
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,19 @@
+# app/models/reservation.rb
+class Reservation < ApplicationRecord
+  belongs_to :user
+  belongs_to :slot
+  belongs_to :menu
+
+  validates :user_id, :slot_id, :menu_id, presence: true
+  validate :slot_must_be_available  # ← ここを追加！
+
+  private
+
+  def slot_must_be_available
+    # 編集時は自分の予約を除外してチェック
+    existing = Reservation.find_by(slot_id: slot_id)
+    if existing && existing.id != self.id
+      errors.add(:slot_id, "はすでに他のユーザーに予約されています")
+    end
+  end
+end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -2,7 +2,10 @@ class Slot < ApplicationRecord
   validates :start_time, :end_time, presence: true
   validate :end_time_after_start_time
   validate :no_overlap
+
   has_many :menus, dependent: :destroy
+  has_many :reservations, dependent: :destroy
+
   private
 
   # 終了時間は開始時間より後であることを保証

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   ROLE = { user: 0, admin: 1 }
 
+  has_many :reservations, dependent: :destroy
+
   def admin?
     role == ROLE[:admin]
   end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,2 +1,41 @@
-<h1>Admin::Dashboard#index</h1>
-<p>Find me in app/views/admin/dashboard/index.html.erb</p>
+<h1>管理ダッシュボード</h1>
+
+<h2>📅 今週の予約一覧</h2>
+<table border="1" cellpadding="6">
+  <thead>
+    <tr>
+      <th>予約日時</th>
+      <th>ユーザー</th>
+      <th>メニュー</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @upcoming_reservations.each do |res| %>
+      <tr>
+        <td><%= res.slot.start_time.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= res.user.email %></td>
+        <td><%= res.menu.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<hr>
+
+<h2>📊 時間帯ごとの予約数サマリー</h2>
+<table border="1" cellpadding="6">
+  <thead>
+    <tr>
+      <th>時間枠（開始〜終了）</th>
+      <th>予約数</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @slot_summary.each do |slot| %>
+      <tr>
+        <td><%= slot.start_time.strftime("%Y/%m/%d %H:%M") %> - <%= slot.end_time.strftime("%H:%M") %></td>
+        <td><%= slot.reservation_count %> 件</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/menus/index.html.erb
+++ b/app/views/admin/menus/index.html.erb
@@ -23,7 +23,7 @@
         <td><%= menu.available ? "○" : "×" %></td>
         <td>
           <%= link_to "編集", edit_admin_menu_path(menu) %> |
-          <%= link_to "削除", admin_menu_path(menu), data: { turbo_method: :delete } %> %>
+          <%= link_to "削除", admin_menu_path(menu), data: { turbo_method: :delete } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/reservations/_form.html.erb
+++ b/app/views/admin/reservations/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with(model: reservation, url: reservation.new_record? ? admin_reservations_path : admin_reservation_path(reservation), local: true) do |form| %>
+  <div>
+    <%= form.label :user_id, "ユーザー" %><br>
+    <%= form.collection_select :user_id, @users, :id, :name, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= form.label :slot_id, "時間枠" %><br>
+    <%= form.collection_select :slot_id, @slots, :id, :start_time, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= form.label :menu_id, "施術メニュー" %><br>
+    <%= form.collection_select :menu_id, @menus, :id, :name, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/reservations/edit.html.erb
+++ b/app/views/admin/reservations/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>予約編集</h1>
+
+<%= render 'form', reservation: @reservation %>
+
+<%= link_to "予約一覧に戻る", admin_reservations_path %>

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -1,0 +1,23 @@
+<table>
+  <thead>
+    <tr>
+      <th>ユーザー</th>
+      <th>時間枠</th>
+      <th>メニュー</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @reservations.each do |reservation| %>
+      <tr>
+        <td><%= reservation.user.name %></td>
+        <td><%= reservation.slot.start_time.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= reservation.menu.name %></td>
+        <td>
+          <%= link_to "編集", edit_admin_reservation_path(reservation) %> |
+          <%= link_to "削除", admin_reservation_path(reservation), method: :delete, data: { confirm: "本当に削除しますか？" } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/reservations/new.html.erb
+++ b/app/views/admin/reservations/new.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/admin/reservations/new.html.erb -->
+<h2>新規予約作成</h2>
+<%= render "form" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,7 +14,7 @@
       <h1>🌤 sorairo note - 管理画面</h1>
       <nav>
         <ul>
-          <li><%= link_to "🏠 ダッシュボード", admin_dashboard_index_path %></li>
+          <li><%= link_to "🏠 ダッシュボード", admin_root_path %></li>
           <li><%= link_to "🕒 時間枠管理", admin_slots_path %></li>
           <li><%= link_to "📋 メニュー管理", admin_menus_path %></li>
           <li><%= link_to "👤 マイページへ", mypage_path %></li>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,2 +1,10 @@
-<h1>Users#mypage</h1>
-<p>Find me in app/views/users/mypage.html.erb</p>
+<!-- app/views/users/mypage.html.erb -->
+
+<h2>マイページ</h2>
+
+<section>
+  <h3>予約</h3>
+  <%= link_to "新しい予約をする", new_users_reservation_path, class: "btn btn-primary" %>
+  <br>
+  <%= link_to "予約一覧を見る", users_reservations_path, class: "btn btn-secondary" %>
+</section>

--- a/app/views/users/reservations/_form.html.erb
+++ b/app/views/users/reservations/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with model: [:users, reservation], local: true do |f| %>
+  <% if reservation.errors.any? %>
+    <div class="error-messages">
+      <ul>
+        <% reservation.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <!-- ユーザー選択は不要 -->
+
+  <div>
+    <%= f.label :slot_id, "時間枠" %><br>
+    <%= f.collection_select :slot_id, slots, :id, :start_time, prompt: "時間枠を選択してください" %>
+  </div>
+
+  <div>
+    <%= f.label :menu_id, "施術メニュー" %><br>
+    <%= f.collection_select :menu_id, menus, :id, :name, prompt: "メニューを選択してください" %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/users/reservations/edit.html.erb
+++ b/app/views/users/reservations/edit.html.erb
@@ -1,0 +1,3 @@
+<h2>予約を編集</h2>
+
+<%= render "form", reservation: @reservation, menus: @menus, slots: @slots, users: @users %>

--- a/app/views/users/reservations/index.html.erb
+++ b/app/views/users/reservations/index.html.erb
@@ -1,0 +1,23 @@
+<h2>予約一覧</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>日時</th>
+      <th>メニュー</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @reservations.each do |reservation| %>
+      <tr>
+        <td><%= reservation.slot.start_time.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= reservation.menu.name %></td>
+        <td>
+          <%= link_to "編集", edit_users_reservation_path(reservation) %>
+          <!-- 削除機能があればここに削除リンクも追加 -->
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/reservations/new.html.erb
+++ b/app/views/users/reservations/new.html.erb
@@ -1,0 +1,3 @@
+<h2>新規予約</h2>
+
+<%= render "form", reservation: @reservation, menus: @menus, slots: @slots, users: @users %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,20 @@
 Rails.application.routes.draw do
-  # 認証系（Devise）
+  # 認証（Devise）
   devise_for :users
 
   # ユーザー機能
   get "users/mypage", to: "users#mypage", as: :mypage
 
-  # 管理者機能（admin名前空間）
+  namespace :users do
+    get "reservations/new"
+    get "reservations/create"
+    get "reservations/edit"
+    get "reservations/update"
+    resources :reservations, only: [ :index, :new, :create, :edit, :update ]
+  end
+
+  # 管理者機能
   namespace :admin do
-    get "dashboard/index"
     root to: "dashboard#index"
     resources :reservations
     resources :slots

--- a/db/migrate/20250702144707_create_reservations.rb
+++ b/db/migrate/20250702144707_create_reservations.rb
@@ -1,0 +1,11 @@
+class CreateReservations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reservations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :slot, null: false, foreign_key: true
+      t.references :menu, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_02_133451) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_02_144707) do
   create_table "menus", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -23,6 +23,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_133451) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slot_id"], name: "index_menus_on_slot_id"
+  end
+
+  create_table "reservations", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "slot_id", null: false
+    t.bigint "menu_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id"], name: "index_reservations_on_menu_id"
+    t.index ["slot_id"], name: "index_reservations_on_slot_id"
+    t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
   create_table "slots", charset: "utf8mb3", force: :cascade do |t|
@@ -48,4 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_133451) do
   end
 
   add_foreign_key "menus", "slots"
+  add_foreign_key "reservations", "menus"
+  add_foreign_key "reservations", "slots"
+  add_foreign_key "reservations", "users"
 end

--- a/test/controllers/users/reservations_controller_test.rb
+++ b/test/controllers/users/reservations_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Users::ReservationsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get users_reservations_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get users_reservations_create_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get users_reservations_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get users_reservations_update_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/reservations.yml
+++ b/test/fixtures/reservations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  slot: one
+  menu: one
+
+two:
+  user: two
+  slot: two
+  menu: two

--- a/test/models/reservation_test.rb
+++ b/test/models/reservation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReservationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

本プルリクエストでは、以下の3つのISSUEに対応する機能をまとめて実装しました。

- ISSUE4：施術メニューの管理機能（管理者用）
- ISSUE5：ユーザーによる予約作成機能
- ISSUE6：管理者用ダッシュボードの基礎構築

## 主な変更点

- `Menu`モデルの作成・管理画面（admin/menus）を追加
- `Reservation`モデルとバリデーション（時間重複の防止）を実装
- `Users::ReservationsController` による予約フォーム機能
- `Admin::DashboardController` による簡易的なダッシュボード表示
- 画面遷移やビュー調整を複数ファイルで実施

## 補足・所感

当初はISSUEごとにブランチを分ける予定でしたが、実装の流れで依存関係が強かったため、feature/issue4 ブランチ内で一気に進めました。
レビュー観点が広くなってしまい恐縮ですが、必要に応じて別ブランチへ再分割・調整も可能です。

